### PR TITLE
tf/weapon: Fix wrong classname in TF2_TranslateWeaponEntForClass

### DIFF
--- a/tf/weapon.inc
+++ b/tf/weapon.inc
@@ -117,7 +117,7 @@ stock bool TF2_TranslateWeaponEntForClass(TFClassType playerClass, char[] classN
 	} else if (StrEqual(className, "saxxy")) {
 		static char SAXXY_CLASSES[][] = {
 			"saxxy", "tf_weapon_bat", "tf_weapon_club", "tf_weapon_shovel", "tf_weapon_bottle", 
-			"tf_weapon_bonesaw", "tf_weapon_fists", "tf_weapon_fireaxe", "tf_weapon_knife",
+			"tf_weapon_bonesaw", "tf_weapon_fireaxe", "tf_weapon_fireaxe", "tf_weapon_knife",
 			"tf_weapon_wrench"
 		};
 		


### PR DESCRIPTION
```
.data:01787510                 dd offset aSaxxy        ; "saxxy"
.data:01787514                 dd offset unk_140F41A - TFClass_Unknown
.data:01787518                 dd offset aTfWeaponBat  ; "tf_weapon_bat" - TFClass_Scout
.data:0178751C                 dd offset aTfWeaponClub ; "tf_weapon_club" - TFClass_Sniper
.data:01787520                 dd offset aTfWeaponShovel ; "tf_weapon_shovel" - TFClass_Soldier
.data:01787524                 dd offset aTfWeaponBottle ; "tf_weapon_bottle" - TFClass_Demoman
.data:01787528                 dd offset aTfWeaponBonesa ; "tf_weapon_bonesaw" - TFClass_Medic
.data:0178752C                 dd offset aTfWeaponFireax ; "tf_weapon_fireaxe" - TFClass_Heavy
.data:01787530                 dd offset aTfWeaponFireax ; "tf_weapon_fireaxe" - TFClass_Pyro
.data:01787534                 dd offset aTfWeaponKnife ; "tf_weapon_knife" - TFClass_Spy
.data:01787538                 dd offset aTfWeaponWrench ; "tf_weapon_wrench" - TFClass_Engineer
```
If the class is heavy, return it to "tf_weapon_fireaxe" instead of "tf_weapon_fists". I don't know when it changed.